### PR TITLE
Added colored output via gchalk

### DIFF
--- a/cmd/dups/hash.go
+++ b/cmd/dups/hash.go
@@ -7,11 +7,14 @@ import (
 	"log"
 	"os"
 	"sync"
+
+	"github.com/enr/dups/lib/colorgen"
 )
 
 type hashes struct {
 	mutex *sync.Mutex
 	wg    *sync.WaitGroup
+	color *colorgen.Generator
 }
 
 func (e *hashes) save(f file) {
@@ -34,9 +37,9 @@ func (e *hashes) save(f file) {
 		}
 		if !quiet && showDups {
 			if first != "" {
-				printFirstDup(h, first)
+				e.printFirstDup(h, first)
 			}
-			printDup(h, f)
+			e.printDup(h, f)
 		}
 	}
 	dups = append(dups, f.id)

--- a/cmd/dups/main.go
+++ b/cmd/dups/main.go
@@ -60,6 +60,11 @@ func init() {
 	pflag.VarP(&excludes, "exclude", "e", "exclude filename glob patterns (can be supplied multiple times)")
 	pflag.VarP(&includes, "include", "i", "only include filename glob patterns (can be supplied multiple times)")
 
+	// These flags are automatically read by go-supportscolor
+	// https://github.com/jwalton/go-supportscolor#info
+	pflag.Bool("color", false, "force colored output")
+	pflag.Bool("no-color", false, "disables colored output")
+
 	pflag.Usage = func() {
 		fmt.Fprintln(os.Stderr, appVersion)
 		fmt.Fprintln(os.Stderr, "Flags:")

--- a/cmd/dups/main.go
+++ b/cmd/dups/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/enr/dups/lib/colorgen"
 	"github.com/enr/dups/lib/core"
 	"github.com/enr/go-files/files"
 	"github.com/spf13/pflag"
@@ -94,6 +95,7 @@ func main() {
 	h := &hashes{
 		mutex: new(sync.Mutex),
 		wg:    new(sync.WaitGroup),
+		color: colorgen.NewGenerator(),
 	}
 
 	go func(*hashes) {

--- a/cmd/dups/utils.go
+++ b/cmd/dups/utils.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/jwalton/gchalk"
 )
 
 func trace() {
@@ -26,29 +28,29 @@ func normalizePath(dirpath string) (string, error) {
 	return p, nil
 }
 
-func printFirstDup(checksum string, fp string) {
+func (e *hashes) printFirstDup(checksum string, fp string) {
 	f := fp
 	if fullPath {
 		f, _ = normalizePath(path.Join(baseDirectory, fp))
 	}
-	p(checksum, f)
+	e.p(checksum, f)
 }
 
-func printDup(checksum string, fil file) {
+func (e *hashes) printDup(checksum string, fil file) {
 	f := fil.id
 	if fullPath {
 		f = fil.path
 	}
-	p(checksum, f)
+	e.p(checksum, f)
 }
 
-func p(checksum string, p string) {
+func (e *hashes) p(checksum string, p string) {
+	colorFn := gchalk.RGB(e.color.GenerateRGB(checksum))
 	if names {
-		logger.Println(p)
+		logger.Println(colorFn(p))
 	} else {
-		logger.Printf("%s %s", checksum, p)
+		logger.Printf("%s %s", colorFn(checksum), p)
 	}
-	//}
 }
 
 // https://gist.github.com/harshavardhana/327e0577c4fed9211f65

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,16 @@ go 1.19
 require (
 	github.com/enr/go-files v0.3.0
 	github.com/enr/runcmd v0.5.0
+	github.com/jwalton/gchalk v1.3.0
+	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/spf13/pflag v1.0.5
 )
 
 require (
 	github.com/extemporalgenome/slug v0.0.0-20150414033109-0320c85e32e0 // indirect
+	github.com/jwalton/go-supportscolor v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
+	golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,12 @@ github.com/enr/runcmd v0.5.0/go.mod h1:zI4QUR/n5ESGh9nKKd0EMR6/bxZfNLP05BxMDU5zx
 github.com/extemporalgenome/slug v0.0.0-20150414033109-0320c85e32e0 h1:0A9+8DBvlpto0mr+SD1NadV5liSIAZkWnvyshwk88Bc=
 github.com/extemporalgenome/slug v0.0.0-20150414033109-0320c85e32e0/go.mod h1:96eSBMO0aE2dcsEygXzIsvGyOf7bM5kWuqVCPEgwLEI=
 github.com/fzipp/gocyclo v0.0.0-20150627053110-6acd4345c835/go.mod h1:BjL/N0+C+j9uNX+1xcNuM9vdSIcXCZrQZUYbXOFbgN8=
+github.com/jwalton/gchalk v1.3.0 h1:uTfAaNexN8r0I9bioRTksuT8VGjrPs9YIXR1PQbtX/Q=
+github.com/jwalton/gchalk v1.3.0/go.mod h1:ytRlj60R9f7r53IAElbpq4lVuPOPNg2J4tJcCxtFqr8=
+github.com/jwalton/go-supportscolor v1.1.0 h1:HsXFJdMPjRUAx8cIW6g30hVSFYaxh9yRQwEWgkAR7lQ=
+github.com/jwalton/go-supportscolor v1.1.0/go.mod h1:hFVUAZV2cWg+WFFC4v8pT2X/S2qUUBYMioBD9AINXGs=
+github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
+github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -32,6 +38,14 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef h1:fPxZ3Umkct3LZ8gK9nbk+DWDJ9fstZa2grBn+lWVKPs=
+golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=

--- a/lib/colorgen/colorgen.go
+++ b/lib/colorgen/colorgen.go
@@ -1,0 +1,53 @@
+package colorgen
+
+import (
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/lucasb-eyer/go-colorful"
+)
+
+// 1/golden ratio (i.e 1/Φ)
+const goldenRatioConjugate = 0.618033988749895
+
+const hsvSaturation = 0.6273
+const hsvValue = 0.7725
+
+var random = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// Generator can generate distinct colors for any number of new keys.
+//
+// Inspired by: [https://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically/]
+type Generator struct {
+	hue       float64
+	knownKeys map[string]float64
+}
+
+// NewGenerator returns a new initialized generator, with a randomly selected
+// seed value.
+func NewGenerator() *Generator {
+	return &Generator{
+		hue:       math.Mod(math.Abs(random.Float64()), 1),
+		knownKeys: make(map[string]float64),
+	}
+}
+
+func (gen *Generator) hueForKey(key string) float64 {
+	if v, ok := gen.knownKeys[key]; ok {
+		return v
+	}
+	gen.hue = math.Mod(gen.hue+goldenRatioConjugate, 1)
+	gen.knownKeys[key] = gen.hue
+	return gen.hue
+}
+
+// GenerateRGB returns R, G, and B values, spanning 0-255, for a given key.
+//
+// - If a key is never seen before, then a new color is generated.
+// - If a key is reused, then the previously generated color for that key is used.
+func (gen *Generator) GenerateRGB(key string) (r, g, b uint8) {
+	hue := gen.hueForKey(key)
+	color := colorful.Hsv(360*hue, hsvSaturation, hsvValue)
+	return color.RGB255()
+}


### PR DESCRIPTION
- Added colored output that reuses the same color on the same checksums.
- Color selection is inspired by https://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically/
- Color printing is done by <https://pkg.go.dev/github.com/jwalton/gchalk>, which has cross-platform support and `--no-color`/`--color` flag support

Preview:

![image](https://user-images.githubusercontent.com/2477952/194625174-a364994d-086f-4fb8-b0cf-d6bd11af1330.png)

