### PR TITLE
Remove deprecated package.

### DIFF
--- a/cmd/dups/hash.go
+++ b/cmd/dups/hash.go
@@ -46,10 +46,10 @@ func (e *hashes) save(f file) {
 
 func hash(fullpath string) (string, error) {
 	fh, err := os.Open(fullpath)
-	defer fh.Close()
 	if err != nil {
 		return "", err
 	}
+	defer fh.Close()
 	h := sha1.New()
 	io.Copy(h, fh)
 	return fmt.Sprintf("%x", h.Sum(nil)), nil

--- a/cmd/dups/main.go
+++ b/cmd/dups/main.go
@@ -117,7 +117,7 @@ func main() {
 		os.Exit(0)
 	}
 	if version {
-		fmt.Printf(appVersion)
+		fmt.Print(appVersion)
 		os.Exit(0)
 	}
 	startTime = time.Now()

--- a/cmd/dups/qac_test.go
+++ b/cmd/dups/qac_test.go
@@ -2,10 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"path"
-	"path/filepath"
 	"testing"
 
 	"github.com/enr/dups/lib/qac"
@@ -23,12 +19,4 @@ func TestCommandExecution2(t *testing.T) {
 			t.Error(s)
 		}
 	}
-}
-
-func cwd(f string) string {
-	dir, err := os.Getwd()
-	if err != nil {
-		log.Fatal(err)
-	}
-	return filepath.ToSlash(path.Join(dir, f))
 }

--- a/cmd/dups/utils.go
+++ b/cmd/dups/utils.go
@@ -72,7 +72,7 @@ func processProbableDuplicate(h *hashes) {
 			// break to avoid panic: sync: negative WaitGroup counter
 			break
 		}
-		if ok == false {
+		if !ok {
 			wg.Done()
 			break
 		}

--- a/lib/qac/guarantor.go
+++ b/lib/qac/guarantor.go
@@ -2,7 +2,7 @@ package qac
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -54,7 +54,7 @@ func verifyStatusExpectation(expectation StatusExpectation, ser *SpecExecutionRe
 
 func verifyOutputExpectation(expectation OutputExpectation, ser *SpecExecutionResult, out string, desc string) {
 	if expectation.File != "" {
-		content, err := ioutil.ReadFile(expectation.File)
+		content, err := os.ReadFile(expectation.File)
 		if err != nil {
 			ser.addError(err)
 			return


### PR DESCRIPTION
* `io/ioutil` has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.
* fix linters
* remove unused function